### PR TITLE
Fix compile_all.sh -c to actually remove stale Makefiles

### DIFF
--- a/compile_all.sh
+++ b/compile_all.sh
@@ -34,7 +34,7 @@ function cleanCompile() {
   IFS=$'\n' qmakefiles=($($findbin . -name \*.pro))
   for qm in ${qmakefiles[@]}; do
     m=$(dirname $qm)/Makefile
-    if [ -e $pm ]; then
+    if [ -e $m ]; then
       rm -f $m
     fi
   done


### PR DESCRIPTION
## Summary
- `cleanCompile()`'s Makefile-removal loop checked `$pm`, which is never assigned anywhere in the script (only `$m` is), so the condition was always false and `rm -f $m` never ran. `./compile_all.sh -c` therefore never removed generated Makefiles.
- One-character-variable-name fix: `$pm` → `$m`.

## Why this matters
Rebuilding the same checkout against a different Qt version/toolchain (e.g. switching branches) leaves stale Makefiles in place even after `-c`. Their self-regeneration rules keep referencing the `qmake` binary path baked in at original generation time, silently relinking against the wrong Qt install instead of the one currently on `PATH`/in `config_cache.sh`. Hit this rebuilding macOS `browser.app` on `migrate/qt6` from a checkout that had previously built `main` against Qt5 — `-c` reported "Cleaning done" but left every subdirectory's Qt5-era Makefile in place.

Fixes #16

## Test plan
- [x] Ran `./compile_all.sh -c` on a checkout with existing Makefiles from a prior build; confirmed all generated Makefiles are removed (previously none were).
- [x] Followed with a fresh `./configure.sh` + `./compile_all.sh -i`; build picks up the current toolchain instead of the stale one baked into the old Makefiles.